### PR TITLE
Update dependencies in pyproject.toml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .
+        pip install -e .[test]
 
     - name: Run tests
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,8 @@ readme = "README.rst"
 requires-python = ">=3.10,<4"
 dependencies = [
     "numpy>=2.0.0",
-    "py~=1.11.0",
-    "pytest~=7.1.3",
-    "setuptools~=59.6.0",
+    "py",
+    "pytest",
     "joblib",
     "ipyparallel",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ readme = "README.rst"
 requires-python = ">=3.10,<4"
 dependencies = [
     "numpy>=2.0.0",
-    "py",
     "pytest",
     "joblib",
     "ipyparallel",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ readme = "README.rst"
 requires-python = ">=3.10,<4"
 dependencies = [
     "numpy>=2.0.0",
-    "pytest",
     "joblib",
     "ipyparallel",
 ]
@@ -19,6 +18,9 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 ]
+
+[project.optional-dependencies]
+test = ["pytest"]
 
 [tool.setuptools]
 packages = ["ivory"]

--- a/test/test_workflow_manager.py
+++ b/test/test_workflow_manager.py
@@ -1,5 +1,6 @@
 from getopt import GetoptError
 from operator import eq
+from pathlib import Path
 
 import pytest
 
@@ -15,6 +16,11 @@ from test.plugin.simple_plugin import SimplePlugin, SimpleEnum
 
 
 class TestWorkflowManager(ContextSensitiveTest):
+    @classmethod
+    def setup_class(cls):
+        # Ensure cache directory exists for tests that require it
+        cache_dir = Path(__file__).parent.parent / "cache"
+        cache_dir.mkdir(exist_ok=True)
 
     def test_launch(self):
         args = ["test.config.workflow_config"]


### PR DESCRIPTION
This PR:
- Remove setuptools from the list of dependencies as it is conflicting with the build requirements.
- Move pytest requirement to option-dependencies, and remove py as it is no longer needed
- Fix workflow manager test, making sure cache folder is created if not exist.