### PR TITLE
build: pin Python version to <3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "ivory"
 dynamic = ["version"]
 description = "Ivory: Simple and flexible workflow engine"
 readme = "README.rst"
-requires-python = ">=3.10,<4"
+requires-python = ">=3.10,<3.13"
 dependencies = [
     "numpy>=2.0.0",
     "joblib",


### PR DESCRIPTION
Currently some tests are still failing when running python 3.13