### PR TITLE
feat: add `prefer` parameter to AbstractParallelJoblibPlugin

### DIFF
--- a/ivory/plugin/abstract_parallel_joblib_plugin.py
+++ b/ivory/plugin/abstract_parallel_joblib_plugin.py
@@ -10,11 +10,14 @@ from ivory.plugin.abstract_plugin import AbstractPlugin
 class AbstractParallelJoblibPlugin(AbstractPlugin):
     """ Abstract plugin for parallelised execution with the `joblib` library. """
 
-    def __init__(self, n_jobs: int, verbose: int):
-        """ Initialise with the number of workers `n_jobs` and the `joblib` verbosity `verbose`. """
+    def __init__(self, n_jobs: int, verbose: int, prefer: str | None = None):
+        """ Initialise with the number of workers `n_jobs` and the `joblib` verbosity `verbose`.
+        :param prefer: joblib backend preference: 'threads', 'processes', or None (default loky).
+        """
         super().__init__()
         self.n_jobs = n_jobs
         self.verbose = verbose
+        self.prefer = prefer
 
     @abstractmethod
     def run_job(self, anything: Any) -> Any:
@@ -35,6 +38,7 @@ class AbstractParallelJoblibPlugin(AbstractPlugin):
         """ Run the plugin using `joblib`. """
         print(f'Starting parallel execution with {self.n_jobs} workers.')
         result_list = Parallel(n_jobs=self.n_jobs,
-                               verbose=self.verbose)(delayed(self.run_job)(i) for i in self.map(**kwargs))
+                               verbose=self.verbose,
+                               prefer=self.prefer)(delayed(self.run_job)(i) for i in self.map(**kwargs))
         print('Finished parallel execution, gathering results...')
         self.gather_and_set_result(result_list, **kwargs)


### PR DESCRIPTION
Adds an optional `prefer` argument to the constructor, allowing callers to specify the joblib backend preference ('threads', 'processes', or None for the default loky backend). The value is forwarded to the `Parallel` call in `call_plugin`, giving subclasses control over concurrency strategy without needing to override the execution method.

If most of the parallel work is numpy based, threads will be faster and save a lot of memory. Current parallelization creates copies of the data used by each job.