### PR TITLE
Add direct config file loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Support for loading pipeline configs from a filesystem path (absolute, relative, or `~`-expanded
+  `.py` file), in addition to the existing dotted module path — configs no longer need to be part of an
+  installed/importable package (`WorkflowManager._load_config`)
+- `test/smoke/` executable smoke-test scripts (`run_file_path_config.sh`, `run_module_config.sh`) that
+  exercise the `ivory` CLI end-to-end
+
+### Changed
+
+- CLI usage text and `docs/configuration.md` updated to document file-path configs
+
 ## [2.2.0] (2026-07-23)
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,12 +2,35 @@
 
 ## Config files are plain Python modules
 
-Ivory configs are **not** YAML/TOML/JSON — they're ordinary Python modules, imported by dotted path
-(e.g. `museek.config.demo`, passed as the last positional CLI argument). A config module defines
+Ivory configs are **not** YAML/TOML/JSON — they're ordinary Python modules. A config module defines
 module-level variables whose names start with an uppercase letter, holding instances of
 `ivory.utils.config_section.ConfigSection` — a plain `dict` subclass. `WorkflowManager` picks these up
 automatically by scanning `dir(module)` for capitalized, `ConfigSection`-typed attributes
 (`WorkflowManager._get_config_section`).
+
+The last positional CLI argument identifies the config, and can be either:
+
+- a **dotted module path** (e.g. `museek.config.demo`), imported the normal way via
+  `importlib.import_module` — the module must already be importable (i.e. on `sys.path`, typically
+  inside an installed/editable package); or
+- a **filesystem path** to a `.py` file (absolute, relative, or `~`-expanded, e.g. `./my_config.py`,
+  `~/configs/my_config.py`) — this does **not** need to be part of an installed/importable package, so
+  configs can live anywhere on disk (e.g. alongside data on a scratch directory).
+
+`WorkflowManager._load_config` picks between the two based on the argument: anything containing a path
+separator or ending in `.py` is treated as a file path, otherwise it's treated as a dotted module name.
+
+Either way, Ivory still needs a live Python *module object* to scan for `ConfigSection` attributes,
+because config files are executable Python rather than declarative data — a file path is just a second
+way to obtain that module object (`importlib.util.spec_from_file_location` + `exec_module`), rather than
+a way to bypass loading it as a module. Each file-based load registers the module in `sys.modules` under
+a fresh, randomly generated (`uuid4`-based) name, so that loading two different file-based configs in
+the same process (e.g. across tests) can't overwrite each other's `sys.modules` entry.
+
+```bash
+ivory --size-x=100 --size-y=100 ./my_config.py
+ivory --size-x=100 --size-y=100 ~/configs/my_config.py
+```
 
 **Required section**: `Pipeline`, with a `plugins` key — either a list of dotted plugin-module strings,
 or a pre-built `ivory.loop.Loop` (see [Architecture](architecture.md#loop-sequencing-and-repetition)).

--- a/ivory/cli/main.py
+++ b/ivory/cli/main.py
@@ -30,15 +30,20 @@ def _usage():
 
     usage = """
     **ivory workflow engine**
-    
+
     Usage:
     ivory [arguments] configuration
-    
+
+    The configuration can be either a dotted module path (e.g. ufig.config.random) or a
+    filesystem path to a .py file (absolute, relative, or ~-expanded), which does not need to
+    be part of an installed package.
+
     Only arguments already preconfigured in the given configuration will be accepted.
     Note: Dashed '-' will be converted into underlines '_' for all the arguments
-    
+
     example:
     - ivory --size-x=100 --size-y=100 ufig.config.random
+    - ivory --size-x=100 --size-y=100 ./my_config.py
     """
     print(usage)
 

--- a/ivory/workflow_manager.py
+++ b/ivory/workflow_manager.py
@@ -6,6 +6,7 @@ import sys
 import uuid
 from enum import Enum
 from getopt import getopt
+from pathlib import Path
 from types import ModuleType
 from typing import Optional, Any
 
@@ -145,9 +146,13 @@ class WorkflowManager:
         filesystem path to a `.py` file (absolute, relative, or `~`-expanded), which does not
         need to be part of an installed/importable package.
         """
-        if os.path.sep in config_name or config_name.endswith(".py"):
-            config_path = os.path.abspath(os.path.expanduser(config_name))
-            if not os.path.exists(config_path):
+        path_separators = (sep for sep in (os.sep, os.altsep) if sep)
+        looks_like_path = any(sep in config_name for sep in path_separators) or config_name.endswith(
+            ".py"
+        )
+        if looks_like_path:
+            config_path = Path(config_name).expanduser().resolve()
+            if not config_path.is_file():
                 raise FileNotFoundError(f"Configuration file not found: {config_path}")
             module_name = f"ivory_dynamic_config_{uuid.uuid4().hex}"
             spec = importlib.util.spec_from_file_location(module_name, config_path)

--- a/ivory/workflow_manager.py
+++ b/ivory/workflow_manager.py
@@ -1,5 +1,9 @@
 import importlib
+import importlib.util
+import os
 import pickle
+import sys
+import uuid
 from enum import Enum
 from getopt import getopt
 from types import ModuleType
@@ -122,7 +126,7 @@ class WorkflowManager:
     def _get_config_sections(self, config_name: str) -> dict[str, ConfigSection]:
         """Returns a potentially empty `dict` of config section names and `ConfigSection`s."""
         result = {}
-        config = importlib.import_module(config_name)
+        config = self._load_config(config_name)
         for section_name in dir(config):
             if config_section := self._get_config_section(config, section_name):
                 result[section_name] = config_section
@@ -133,6 +137,27 @@ class WorkflowManager:
                 result[ConfigKeys.PIPELINE.value][ConfigKeys.CONTEXT.value] = None
         
         return result
+
+    @staticmethod
+    def _load_config(config_name: str) -> ModuleType:
+        """
+        Load a config either as a dotted module name (e.g. 'museek.config.demo') or as a
+        filesystem path to a `.py` file (absolute, relative, or `~`-expanded), which does not
+        need to be part of an installed/importable package.
+        """
+        if os.path.sep in config_name or config_name.endswith(".py"):
+            config_path = os.path.abspath(os.path.expanduser(config_name))
+            if not os.path.exists(config_path):
+                raise FileNotFoundError(f"Configuration file not found: {config_path}")
+            module_name = f"ivory_dynamic_config_{uuid.uuid4().hex}"
+            spec = importlib.util.spec_from_file_location(module_name, config_path)
+            if spec is None or spec.loader is None:
+                raise ImportError(f"Could not load configuration from {config_path}")
+            config = importlib.util.module_from_spec(spec)
+            sys.modules[module_name] = config
+            spec.loader.exec_module(config)
+            return config
+        return importlib.import_module(config_name)
 
     @staticmethod
     def _get_config_section(config: ModuleType, section_name: str) -> Optional[Any]:

--- a/test/smoke/run_file_path_config.sh
+++ b/test/smoke/run_file_path_config.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Smoke test: run the ivory CLI end-to-end against a config loaded from a
+# filesystem path that lives outside the ivory package/repo tree.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+
+# The smoke config below reuses the repo's `test.plugin.simple_plugin` test
+# fixture, which is only importable with the repo root on PYTHONPATH (it is
+# not part of the installed `ivory` distribution). See docs/configuration.md
+# for why file-based configs still load through Python's module machinery.
+export PYTHONPATH="${repo_root}${PYTHONPATH:+:${PYTHONPATH}}"
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+config_path="${temp_dir}/standalone_config.py"
+cat > "${config_path}" <<'EOF'
+from ivory.utils.config_section import ConfigSection
+
+Pipeline = ConfigSection(plugins=["test.plugin.simple_plugin"])
+SimplePlugin = ConfigSection(value="hello from a file-path config")
+EOF
+
+echo "Running: uv run ivory ${config_path}"
+cd "${repo_root}"
+uv run ivory "${config_path}"
+
+echo "OK: file-path config ran successfully"

--- a/test/smoke/run_module_config.sh
+++ b/test/smoke/run_module_config.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Regression smoke test: confirm the ivory CLI still runs a config given as a
+# dotted module path (the pre-existing route), unaffected by file-path support.
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+
+# `test.config.workflow_config` and `test.plugin.simple_plugin` are only
+# importable with the repo root on PYTHONPATH (see run_file_path_config.sh).
+export PYTHONPATH="${repo_root}${PYTHONPATH:+:${PYTHONPATH}}"
+
+cd "${repo_root}"
+echo "Running: uv run ivory test.config.workflow_config"
+uv run ivory test.config.workflow_config
+
+echo "OK: module-path config ran successfully"

--- a/test/test_workflow_manager.py
+++ b/test/test_workflow_manager.py
@@ -232,15 +232,17 @@ class TestWorkflowManager(ContextSensitiveTest):
             "Pipeline = ConfigSection(plugins=['test.plugin.simple_plugin'])\n"
             "TestSection = ConfigSection(test_param='from_relative_file')\n"
         )
-        config_filename = "test_relative_workflow_config.py"
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".py", dir=".", delete=False
+        ) as f:
+            f.write(config_content)
+            config_path = Path(f.name)
+
         try:
-            with open(config_filename, "w") as f:
-                f.write(config_content)
-            mgr = WorkflowManager([f"./{config_filename}"])
+            mgr = WorkflowManager([f"./{config_path.name}"])
             assert ctx().params.TestSection.test_param == "from_relative_file"
         finally:
-            if os.path.exists(config_filename):
-                os.unlink(config_filename)
+            config_path.unlink(missing_ok=True)
 
     def test_load_config_file_not_found(self):
         args = ["/non/existent/path/config.py"]

--- a/test/test_workflow_manager.py
+++ b/test/test_workflow_manager.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 from getopt import GetoptError
 from operator import eq
 from pathlib import Path
@@ -205,6 +207,84 @@ class TestWorkflowManager(ContextSensitiveTest):
             }
         )
         assert isinstance(config.Pipeline.plugins, Loop)
+
+    def test_load_config_from_file_path_absolute(self):
+        config_content = (
+            "from ivory.utils.config_section import ConfigSection\n\n"
+            "Pipeline = ConfigSection(plugins=['test.plugin.simple_plugin'])\n"
+            "TestSection = ConfigSection(test_param='from_absolute_file')\n"
+        )
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+            f.write(config_content)
+            temp_config_path = f.name
+
+        try:
+            mgr = WorkflowManager([temp_config_path])
+            assert ctx().params is not None
+            assert ctx().params.Pipeline.plugins is not None
+            assert ctx().params.TestSection.test_param == "from_absolute_file"
+        finally:
+            os.unlink(temp_config_path)
+
+    def test_load_config_from_file_path_relative(self):
+        config_content = (
+            "from ivory.utils.config_section import ConfigSection\n\n"
+            "Pipeline = ConfigSection(plugins=['test.plugin.simple_plugin'])\n"
+            "TestSection = ConfigSection(test_param='from_relative_file')\n"
+        )
+        config_filename = "test_relative_workflow_config.py"
+        try:
+            with open(config_filename, "w") as f:
+                f.write(config_content)
+            mgr = WorkflowManager([f"./{config_filename}"])
+            assert ctx().params.TestSection.test_param == "from_relative_file"
+        finally:
+            if os.path.exists(config_filename):
+                os.unlink(config_filename)
+
+    def test_load_config_file_not_found(self):
+        args = ["/non/existent/path/config.py"]
+        with pytest.raises(FileNotFoundError):
+            WorkflowManager(args)
+
+    def test_load_config_module_name_still_works(self):
+        # Regression: dotted module names must still resolve via the module branch,
+        # not be misclassified as a file path.
+        args = ["test.config.workflow_config"]
+        mgr = WorkflowManager(args)
+        assert ctx().params.Pipeline.plugins is not None
+
+    def test_load_config_two_file_based_configs_do_not_collide(self):
+        content_a = (
+            "from ivory.utils.config_section import ConfigSection\n\n"
+            "Pipeline = ConfigSection(plugins=['test.plugin.simple_plugin'])\n"
+            "TestSection = ConfigSection(test_param='config_a')\n"
+        )
+        content_b = (
+            "from ivory.utils.config_section import ConfigSection\n\n"
+            "Pipeline = ConfigSection(plugins=['test.plugin.simple_plugin'])\n"
+            "TestSection = ConfigSection(test_param='config_b')\n"
+        )
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+            f.write(content_a)
+            path_a = f.name
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+            f.write(content_b)
+            path_b = f.name
+
+        try:
+            module_a = WorkflowManager._load_config(path_a)
+            module_b = WorkflowManager._load_config(path_b)
+            assert module_a is not module_b
+            assert module_a.TestSection["test_param"] == "config_a"
+            assert module_b.TestSection["test_param"] == "config_b"
+        finally:
+            os.unlink(path_a)
+            os.unlink(path_b)
+
+    def test_load_config_via_load_config_static_method(self):
+        module = WorkflowManager._load_config("test.config.workflow_config")
+        assert module.Pipeline["plugins"] is not None
 
     def test_load_context_into_ctx(self):
         from enum import Enum


### PR DESCRIPTION
This PR add an ability to load config file from a direct file path.

Previously, the config file needs to live inside a module as it is just a Python module `.py` file and ivory simply loads it by importing it. There is no good way around this due to the `.py` file limitation.

With this PR, the config file no longer need to be inside a module; it can be a standalone file. `uuid4`, a Python's standard library for generating a random UUID is used to build a unique dummy module name each time a file-based config is loaded.